### PR TITLE
Update android dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,19 @@
 buildscript {
     repositories {
         jcenter()
+        google()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
-        classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:1.1.0'
+        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'gradle.plugin.org.codehaus.groovy:groovy-android-gradle-plugin:3.0.0'
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'groovyx.android'
+apply plugin: "org.codehaus.groovy.android"
 
 android {
     compileSdkVersion 23


### PR DESCRIPTION
Update android dependencies to handle gradle > 6 for upgrading to React Native 0.62.2